### PR TITLE
remove superfluous (deprecated) includes

### DIFF
--- a/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
+++ b/stomp_plugins/include/stomp_plugins/cost_functions/tool_goal_pose.h
@@ -28,8 +28,6 @@
 
 #include <Eigen/Sparse>
 #include <moveit/robot_model/robot_model.h>
-#include <moveit/collision_detection_fcl/collision_world_fcl.h>
-#include <moveit/collision_detection_fcl/collision_robot_fcl.h>
 #include <stomp_moveit/utils/kinematics.h>
 #include "stomp_moveit/cost_functions/stomp_cost_function.h"
 


### PR DESCRIPTION
tiny follow-up to keep the collision-API changes together. @simonschmeisser